### PR TITLE
Enhance `@actions/core` output catching

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -61,7 +61,6 @@
   },
   "env": {
     "node": true,
-    "es6": true,
-    "jest/globals": true
+    "es6": true
   }
 }

--- a/.github/workflows/update-coverage-in-readme.yml
+++ b/.github/workflows/update-coverage-in-readme.yml
@@ -7,7 +7,6 @@ on:
       - '.github/**'
       - 'data/**'
       - 'dist/**'
-      - '**/app/local/**'
 
 jobs:
   update-coverage-in-readme:
@@ -39,14 +38,14 @@ jobs:
         run: npm run build
 
       - name: Run Tests
-        run: npm run test:coverage
+        run: npm run test:coverage | tee ./coverage.txt
 
       - name: Jest Coverage Comment
         id: coverageComment
         uses: MishaKav/jest-coverage-comment@main
         with:
           hide-comment: true
-          coverage-summary-path: ./coverage/coverage-summary.json
+          coverage-path: ./coverage.txt
           junitxml-path: ./coverage/junit.xml
 
       - name: Check the output coverage

--- a/__tests__/coverage.test.ts
+++ b/__tests__/coverage.test.ts
@@ -1,7 +1,9 @@
-import * as core from '@actions/core'
-import { expect, test, describe, jest } from '@jest/globals'
+import { expect, test, describe } from '@jest/globals'
 import { getCoverageReport } from '../src/coverage'
 import { Options } from '../src/types'
+import { setup, spyCore } from './setup'
+
+setup()
 
 describe('get coverage report', () => {
   const options: Options = {
@@ -141,7 +143,6 @@ describe('get coverage report', () => {
   })
 
   test('should return default report on error', () => {
-    const spy = jest.spyOn(core, 'error')
     const optionsWithWrongFile = {
       ...options,
       coverageFile: options.summaryFile,
@@ -156,8 +157,8 @@ describe('get coverage report', () => {
       statements,
     } = getCoverageReport(optionsWithWrongFile)
 
-    expect(spy).toHaveBeenCalledTimes(1)
-    expect(spy).toHaveBeenCalledWith(
+    expect(spyCore.error).toHaveBeenCalledTimes(1)
+    expect(spyCore.error).toHaveBeenCalledWith(
       "Generating coverage report. Cannot read properties of undefined (reading 'length')"
     )
     expect(coverageHtml).toBe('')

--- a/__tests__/coverage.test.ts
+++ b/__tests__/coverage.test.ts
@@ -1,9 +1,7 @@
 import { expect, test, describe } from '@jest/globals'
 import { getCoverageReport } from '../src/coverage'
 import { Options } from '../src/types'
-import { setup, spyCore } from './setup'
-
-setup()
+import { spyCore } from './setup'
 
 describe('get coverage report', () => {
   const options: Options = {

--- a/__tests__/junit.test.ts
+++ b/__tests__/junit.test.ts
@@ -1,8 +1,6 @@
 import { expect, test, describe } from '@jest/globals'
 import { getJunitReport, parseJunit, junitToMarkdown } from '../src/junit'
-import { setup, spyCore } from './setup'
-
-setup()
+import { spyCore } from './setup'
 
 describe('parsing junit', () => {
   test('should parse xml string to junit', async () => {

--- a/__tests__/junit.test.ts
+++ b/__tests__/junit.test.ts
@@ -1,6 +1,8 @@
-import * as core from '@actions/core'
-import { expect, test, describe, jest } from '@jest/globals'
+import { expect, test, describe } from '@jest/globals'
 import { getJunitReport, parseJunit, junitToMarkdown } from '../src/junit'
+import { setup, spyCore } from './setup'
+
+setup()
 
 describe('parsing junit', () => {
   test('should parse xml string to junit', async () => {
@@ -24,33 +26,30 @@ describe('parsing junit', () => {
   })
 
   test('should return null when no content', async () => {
-    const spy = jest.spyOn(core, 'warning')
     const junit = await parseJunit(null as never)
 
     expect(junit).toBeNull()
-    expect(spy).toHaveBeenCalledTimes(1)
-    expect(spy).toHaveBeenCalledWith('JUnit XML was not provided')
+    expect(spyCore.warning).toHaveBeenCalledTimes(1)
+    expect(spyCore.warning).toHaveBeenCalledWith('JUnit XML was not provided')
   })
 
   test('should return null on not well formed files', async () => {
-    const spy = jest.spyOn(core, 'warning')
     const xml = '<?xml version="1.0" encoding="UTF-8"?>'
     const junit = await parseJunit(xml)
 
     expect(junit).toBeNull()
-    expect(spy).toHaveBeenCalledTimes(1)
-    expect(spy).toHaveBeenCalledWith(
+    expect(spyCore.warning).toHaveBeenCalledTimes(1)
+    expect(spyCore.warning).toHaveBeenCalledWith(
       'JUnit XML file is not XML or not well formed'
     )
   })
 
   test('should throw error on non XML files', async () => {
-    const spy = jest.spyOn(core, 'error')
     const junit = await parseJunit('bad content')
 
     expect(junit).toBeNull()
-    expect(spy).toHaveBeenCalledTimes(1)
-    expect(spy).toHaveBeenCalledWith(
+    expect(spyCore.error).toHaveBeenCalledTimes(1)
+    expect(spyCore.error).toHaveBeenCalledWith(
       'Parse JUnit report. Non-whitespace before first tag.\nLine: 0\nColumn: 1\nChar: b'
     )
   })

--- a/__tests__/multi-files.test.ts
+++ b/__tests__/multi-files.test.ts
@@ -1,8 +1,6 @@
 import { expect, test, describe } from '@jest/globals'
 import { getMultipleReport } from '../src/multi-files'
-import { setup, spyCore } from './setup'
-
-setup()
+import { spyCore } from './setup'
 
 describe('multi report', () => {
   test('should not parse when no files', () => {

--- a/__tests__/multi-files.test.ts
+++ b/__tests__/multi-files.test.ts
@@ -1,6 +1,8 @@
-import * as core from '@actions/core'
-import { expect, test, describe, jest } from '@jest/globals'
+import { expect, test, describe } from '@jest/globals'
 import { getMultipleReport } from '../src/multi-files'
+import { setup, spyCore } from './setup'
+
+setup()
 
 describe('multi report', () => {
   test('should not parse when no files', () => {
@@ -12,30 +14,30 @@ describe('multi report', () => {
   })
 
   test('should throw error on bad format', () => {
-    const spy = jest.spyOn(core, 'error')
     const result = getMultipleReport({
       multipleFiles: ['./path/to/file.json'],
     } as never)
 
     expect(result).toBeNull()
-    expect(spy).toHaveBeenCalledTimes(1)
-    expect(spy).toHaveBeenCalledWith(
+    expect(spyCore.error).toHaveBeenCalledTimes(1)
+    expect(spyCore.error).toHaveBeenCalledWith(
       'Generating summary report for multiple files. No files are provided'
     )
   })
 
   test('should throw warning when file not exist', () => {
-    const spy = jest.spyOn(core, 'warning')
     const result = getMultipleReport({
       multipleFiles: ['title1, ./path/to/file.json'],
     } as never)
 
     expect(result).toBeNull()
-    expect(spy).toHaveBeenCalledTimes(2)
-    expect(spy).toHaveBeenCalledWith(
+    expect(spyCore.warning).toHaveBeenCalledTimes(2)
+    expect(spyCore.warning).toHaveBeenCalledWith(
       'File "./path/to/file.json" doesn\'t exist'
     )
-    expect(spy).toHaveBeenCalledWith('Summary JSON was not provided')
+    expect(spyCore.warning).toHaveBeenCalledWith(
+      'Summary JSON was not provided'
+    )
   })
 
   test('should generate markdown for one file', () => {

--- a/__tests__/multi-junit-files.test.ts
+++ b/__tests__/multi-junit-files.test.ts
@@ -1,6 +1,8 @@
-import * as core from '@actions/core'
-import { expect, test, describe, jest } from '@jest/globals'
+import { expect, test, describe } from '@jest/globals'
 import { getMultipleJunitReport } from '../src/multi-junit-files'
+import { setup, spyCore } from './setup'
+
+setup()
 
 describe('multi junit report', () => {
   test('should not parse when no files', async () => {
@@ -16,28 +18,28 @@ describe('multi junit report', () => {
   })
 
   test('should throw error on bad format', async () => {
-    const spy = jest.spyOn(core, 'error')
     const result = await getMultipleJunitReport({
       multipleJunitFiles: ['./path/to/file.xml'],
     } as never)
 
     expect(result).toBeNull()
-    expect(spy).toHaveBeenCalledTimes(1)
-    expect(spy).toHaveBeenCalledWith(
+    expect(spyCore.error).toHaveBeenCalledTimes(1)
+    expect(spyCore.error).toHaveBeenCalledWith(
       'Generating report for multiple JUnit files. No files are provided'
     )
   })
 
   test('should throw warning when file not exist', async () => {
-    const spy = jest.spyOn(core, 'warning')
     const result = await getMultipleJunitReport({
       multipleJunitFiles: ['title1, ./path/to/junit.xml'],
     } as never)
 
     expect(result).toBeNull()
-    expect(spy).toHaveBeenCalledTimes(2)
-    expect(spy).toHaveBeenCalledWith(`File "./path/to/junit.xml" doesn't exist`)
-    expect(spy).toHaveBeenCalledWith('JUnit XML was not provided')
+    expect(spyCore.warning).toHaveBeenCalledTimes(2)
+    expect(spyCore.warning).toHaveBeenCalledWith(
+      `File "./path/to/junit.xml" doesn't exist`
+    )
+    expect(spyCore.warning).toHaveBeenCalledWith('JUnit XML was not provided')
   })
 
   test('should generate markdown for one file', async () => {

--- a/__tests__/multi-junit-files.test.ts
+++ b/__tests__/multi-junit-files.test.ts
@@ -1,8 +1,6 @@
 import { expect, test, describe } from '@jest/globals'
 import { getMultipleJunitReport } from '../src/multi-junit-files'
-import { setup, spyCore } from './setup'
-
-setup()
+import { spyCore } from './setup'
 
 describe('multi junit report', () => {
   test('should not parse when no files', async () => {

--- a/__tests__/parse-coverage.test.ts
+++ b/__tests__/parse-coverage.test.ts
@@ -7,6 +7,10 @@ import {
   exportedForTesting,
 } from '../src/parse-coverage'
 import { CoverageLine } from '../src/types'
+import { setup } from './setup'
+
+setup()
+
 const {
   parseLine,
   isHeaderLine,

--- a/__tests__/parse-coverage.test.ts
+++ b/__tests__/parse-coverage.test.ts
@@ -7,9 +7,6 @@ import {
   exportedForTesting,
 } from '../src/parse-coverage'
 import { CoverageLine } from '../src/types'
-import { setup } from './setup'
-
-setup()
 
 const {
   parseLine,

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -1,0 +1,24 @@
+import * as core from '@actions/core'
+import { beforeAll, jest } from '@jest/globals'
+import type { SpyInstance } from 'jest-mock'
+
+type Keys = 'info' | 'warning' | 'error' | 'startGroup' | 'endGroup'
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const spyCore: { [key in Keys]?: SpyInstance<any> } = {}
+
+/**
+ * Spy and mock functions from '@actions/core'
+ * to make sure the console doesn't get polluted
+ * and the output won't be interpreted in CI.
+ */
+export function setup(): void {
+  beforeAll(() => {
+    spyCore.info = jest.spyOn(core, 'info').mockImplementation(() => {})
+    spyCore.warning = jest.spyOn(core, 'warning').mockImplementation(() => {})
+    spyCore.error = jest.spyOn(core, 'error').mockImplementation(() => {})
+    spyCore.startGroup = jest
+      .spyOn(core, 'startGroup')
+      .mockImplementation(() => {})
+    spyCore.endGroup = jest.spyOn(core, 'endGroup').mockImplementation(() => {})
+  })
+}

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -1,24 +1,13 @@
 import * as core from '@actions/core'
-import { beforeAll, jest } from '@jest/globals'
-import type { SpyInstance } from 'jest-mock'
+import { jest } from '@jest/globals'
 
-type Keys = 'info' | 'warning' | 'error' | 'startGroup' | 'endGroup'
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const spyCore: { [key in Keys]?: SpyInstance<any> } = {}
-
-/**
- * Spy and mock functions from '@actions/core'
- * to make sure the console doesn't get polluted
- * and the output won't be interpreted in CI.
- */
-export function setup(): void {
-  beforeAll(() => {
-    spyCore.info = jest.spyOn(core, 'info').mockImplementation(() => {})
-    spyCore.warning = jest.spyOn(core, 'warning').mockImplementation(() => {})
-    spyCore.error = jest.spyOn(core, 'error').mockImplementation(() => {})
-    spyCore.startGroup = jest
-      .spyOn(core, 'startGroup')
-      .mockImplementation(() => {})
-    spyCore.endGroup = jest.spyOn(core, 'endGroup').mockImplementation(() => {})
-  })
+// Spy and mock functions from '@actions/core'
+// to make sure the console doesn't get polluted
+// and the output won't be interpreted in CI.
+export const spyCore = {
+  info: jest.spyOn(core, 'info').mockImplementation(() => {}),
+  warning: jest.spyOn(core, 'warning').mockImplementation(() => {}),
+  error: jest.spyOn(core, 'error').mockImplementation(() => {}),
+  startGroup: jest.spyOn(core, 'startGroup').mockImplementation(() => {}),
+  endGroup: jest.spyOn(core, 'endGroup').mockImplementation(() => {}),
 }

--- a/__tests__/summary.test.ts
+++ b/__tests__/summary.test.ts
@@ -1,5 +1,4 @@
-import * as core from '@actions/core'
-import { expect, test, describe, jest } from '@jest/globals'
+import { expect, test, describe } from '@jest/globals'
 import {
   getSummaryReport,
   parseSummary,
@@ -9,6 +8,10 @@ import {
 } from '../src/summary'
 import { Options } from '../src/types'
 import { getContentFile } from '../src/utils'
+import { setup, spyCore } from './setup'
+
+setup()
+
 const { lineSummaryToTd } = exportedForTesting
 
 describe('coverage from summary', () => {
@@ -100,12 +103,11 @@ describe('should parse summary', () => {
   })
 
   test('should throw error on parsing', () => {
-    const spy = jest.spyOn(core, 'error')
     const parsedSummary = parseSummary('bad content')
 
     expect(parsedSummary).toBeNull()
-    expect(spy).toHaveBeenCalledTimes(1)
-    expect(spy).toHaveBeenCalledWith(
+    expect(spyCore.error).toHaveBeenCalledTimes(1)
+    expect(spyCore.error).toHaveBeenCalledWith(
       'Parse summary report. Unexpected token b in JSON at position 0'
     )
   })

--- a/__tests__/summary.test.ts
+++ b/__tests__/summary.test.ts
@@ -8,9 +8,7 @@ import {
 } from '../src/summary'
 import { Options } from '../src/types'
 import { getContentFile } from '../src/utils'
-import { setup, spyCore } from './setup'
-
-setup()
+import { spyCore } from './setup'
 
 const { lineSummaryToTd } = exportedForTesting
 

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,19 +1,14 @@
-import * as core from '@actions/core'
 import { readFileSync } from 'fs'
-import {
-  expect,
-  test,
-  describe,
-  jest,
-  beforeAll,
-  afterAll,
-} from '@jest/globals'
+import { expect, test, describe, beforeAll, afterAll } from '@jest/globals'
 import {
   getContentFile,
   getCoverageColor,
   getPathToFile,
   parseLine,
 } from '../src/utils'
+import { setup, spyCore } from './setup'
+
+setup()
 
 describe('should check all utils functions', () => {
   const GITHUB_WORKSPACE = process.cwd()
@@ -46,51 +41,48 @@ describe('should check all utils functions', () => {
 
   describe('should check getContentFile', () => {
     test('should return empty string', () => {
-      const spy = jest.spyOn(core, 'warning')
       const content = getContentFile('')
 
       expect(content).toEqual('')
-      expect(spy).toHaveBeenCalledTimes(1)
-      expect(spy).toHaveBeenCalledWith('Path to file was not provided')
+      expect(spyCore.warning).toHaveBeenCalledTimes(1)
+      expect(spyCore.warning).toHaveBeenCalledWith(
+        'Path to file was not provided'
+      )
     })
 
     test('should return empty string on non exist file', () => {
-      const spy = jest.spyOn(core, 'warning')
       const content = getContentFile('non-exist-file.json')
 
       expect(content).toEqual('')
-      expect(spy).toHaveBeenCalledTimes(1)
-      expect(spy).toHaveBeenCalledWith(
+      expect(spyCore.warning).toHaveBeenCalledTimes(1)
+      expect(spyCore.warning).toHaveBeenCalledWith(
         `File "non-exist-file.json" doesn't exist`
       )
     })
 
     test('should return empty content on empty file', () => {
-      const spy = jest.spyOn(core, 'warning')
       const pathToFile = '__mocks__/empty.json'
       const content = getContentFile(pathToFile)
 
-      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spyCore.warning).toHaveBeenCalledTimes(1)
       expect(content).toEqual('')
-      expect(spy).toHaveBeenCalledWith(
+      expect(spyCore.warning).toHaveBeenCalledWith(
         `No content found in file "${pathToFile}"`
       )
     })
 
     test('should return empty content on empty file', () => {
-      const spy = jest.spyOn(core, 'warning')
       const pathToFile = '__mocks__/empty.json'
       const content = getContentFile(pathToFile)
 
-      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spyCore.warning).toHaveBeenCalledTimes(1)
       expect(content).toEqual('')
-      expect(spy).toHaveBeenCalledWith(
+      expect(spyCore.warning).toHaveBeenCalledWith(
         `No content found in file "${pathToFile}"`
       )
     })
 
     test('should return full content on file', () => {
-      const spy = jest.spyOn(core, 'info')
       const pathToFile = '__mocks__/coverage.txt'
       const originalContent = readFileSync(
         `${GITHUB_WORKSPACE}/${pathToFile}`,
@@ -98,9 +90,11 @@ describe('should check all utils functions', () => {
       )
       const content = getContentFile(pathToFile)
 
-      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spyCore.info).toHaveBeenCalledTimes(1)
       expect(content).toEqual(originalContent)
-      expect(spy).toHaveBeenCalledWith(`File read successfully "${pathToFile}"`)
+      expect(spyCore.info).toHaveBeenCalledWith(
+        `File read successfully "${pathToFile}"`
+      )
     })
   })
 

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -6,9 +6,7 @@ import {
   getPathToFile,
   parseLine,
 } from '../src/utils'
-import { setup, spyCore } from './setup'
-
-setup()
+import { spyCore } from './setup'
 
 describe('should check all utils functions', () => {
   const GITHUB_WORKSPACE = process.cwd()

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
   transform: {
     '^.+\\.ts$': 'ts-jest',
   },
+  setupFilesAfterEnv: ['<rootDir>/__tests__/setup.ts'],
   collectCoverageFrom: ['src/**/*.ts'],
   coveragePathIgnorePatterns: [
     'src/cli.ts',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,3 @@
-// Turn off stdout in tests, so console doesn't get polluted by it and core output isn't interpreted in CI
-process.stdout.write = () => {
-  return false
-}
-
 module.exports = {
   clearMocks: true,
   moduleFileExtensions: ['js', 'ts'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
   },
-  "exclude": ["node_modules", "**/*.test.ts"]
+  "exclude": ["node_modules", "**/*.test.ts", "__tests__/setup.ts"]
 }


### PR DESCRIPTION
With the previous method the coverage output was no longer getting printed, see https://github.com/MishaKav/jest-coverage-comment/pull/39#discussion_r1008935952.

This also reverts the workaround introduced in #41.