### PR TITLE
Handle case when testsuites is not the root element of the JUnit xml file

### DIFF
--- a/__tests__/junit.test.ts
+++ b/__tests__/junit.test.ts
@@ -51,6 +51,18 @@ describe('parsing junit', () => {
       'Parse JUnit report. Non-whitespace before first tag.\nLine: 0\nColumn: 1\nChar: b'
     )
   })
+
+  test('should work with omitted parent testsuites element', async () => {
+    const xml =
+      '<?xml version="1.0" encoding="UTF-8"?><testsuite name="should test controller" errors="0" failures="0" skipped="0" timestamp="2022-03-21T21:15:26" time="0.981" tests="2"><testcase classname="should test controller when #getPost method method succeeds" name="should test controller when #getPost method method succeeds" time="0.004"></testcase><testcase classname="should test controller when #getPost method method fails" name="should test controller when #getPost method method fails" time="0.001"></testcase></testsuite>'
+    const junit = await parseJunit(xml)
+
+    expect(junit?.skipped).toBe(0)
+    expect(junit?.errors).toBe(0)
+    expect(junit?.failures).toBe(0)
+    expect(junit?.tests).toBe(2)
+    expect(junit?.time).toBe(0.981)
+  })
 })
 
 describe('parse junit and check report output', () => {

--- a/src/junit.ts
+++ b/src/junit.ts
@@ -20,8 +20,18 @@ export async function parseJunit(xmlContent: string): Promise<Junit | null> {
       return null
     }
 
-    const main = parsedJunit.testsuites['$']
-    const testsuites = parsedJunit.testsuites.testsuite
+    /**
+     * <testsuites> Usually the root element of a JUnit XML file. Some tools leave out
+     * the <testsuites> element if there is only a single top-level <testsuite> element (which
+     * is then used as the root element).
+     */
+    const main = parsedJunit.testsuites?.$ ?? parsedJunit.testsuite?.$
+    const testsuites = parsedJunit.testsuites?.testsuite
+      ? parsedJunit.testsuites?.testsuite
+      : parsedJunit.testsuite
+      ? [parsedJunit.testsuite]
+      : null
+
     const errors =
       testsuites
         ?.map((t: any) => Number(t['$'].errors))


### PR DESCRIPTION
Updates the junit parsing to account for cases where tools may not utilize `<testsuites>` as the root element.

Without this change, trying to parse a junit xml file that omits the root testsuites element results in this error:

> Parse JUnit report. Cannot read properties of undefined (reading '$')

As explained on this page, the JUnit xml format has no official specification and many tools and projects have minor variations such as this. [Common JUnit XML Format & Examples
](https://github.com/testmoapp/junitxml)