### PR TITLE
Refresh CLAUDE.md guidance after prompt audit [skip ci]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,10 @@ The action follows a modular architecture:
 - **Main Entry**: `src/index.ts` - Orchestrates the entire workflow, gathering inputs and coordinating report generation
 - **Report Generators**: Separate modules for each report type (coverage, junit, summary, multi-file reports)
 - **Comment Management**: `src/create-comment.ts` handles GitHub API interactions for creating/updating PR comments
+- **Changed Files**: `src/changed-files.ts` queries the GitHub API for the files a PR touched, used for PR-only reporting
+- **Path Repair**: `src/fix-coverage-paths.ts` restores real file paths in coverage output so links resolve (matters for `jest --changedSince`)
 - **Utilities**: Helper functions in `src/utils.ts` for common operations
+- **Local Harness**: `src/cli.ts` runs the generators against the `data/` fixtures for local debugging; it is not part of the action runtime and is excluded from coverage
 
 The action supports multiple report formats:
 
@@ -58,7 +61,7 @@ npm run all
 
 ## Versioning and Changelog
 
-Every feature or fix PR must bump the version and update the changelog in the same PR — don't forget this step:
+Every feature or fix PR must bump the version and update the changelog in the same PR:
 
 1. Bump the version with `npm version patch --no-git-tag-version` (updates `package.json` and `package-lock.json`; the action uses `1.0.x` patch increments for features and fixes alike)
 2. Add a new entry at the top of `CHANGELOG.md` in the existing format:


### PR DESCRIPTION
Result of a `/claude-api prompt-audit` pass over the repo's prompt surface.

- Core Architecture now documents `src/changed-files.ts`, `src/fix-coverage-paths.ts`, and `src/cli.ts` (all three were missing).
- Dropped the "don't forget this step" reminder from the versioning rule; the requirement itself is unchanged.

Docs only, no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes `CLAUDE.md` guidance after a prompt audit so the architecture docs list the current modules and the versioning rule reads more clearly.

- Adds `src/changed-files.ts`, `src/fix-coverage-paths.ts`, and `src/cli.ts` to the Core Architecture section.
- Removes the “don’t forget this step” reminder from the versioning rule; the rule itself is unchanged.
- Docs only, no code or behavior change.

<sup>Written for commit a72647909d4c88edc1237d658d53effd7ddadbd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MishaKav/jest-coverage-comment/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

